### PR TITLE
Removed numbering by default

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -26,7 +26,6 @@ Plug 'plasticboy/vim-markdown'
 call plug#end()
 
 " Colorscheme
-set number
 syntax enable
 set background=dark
 colorscheme solarized


### PR DESCRIPTION
Line numbering enabled by default does not always allow to copy the content correctly.

Removed from the default settings.